### PR TITLE
null terminate file info altname

### DIFF
--- a/fat.go
+++ b/fat.go
@@ -1945,6 +1945,9 @@ func (dp *dir) get_fileinfo(fno *FileInfo) {
 		}
 		di += nw
 	}
+	// terminate altname
+	fno.altname[di] = 0
+
 	if fno.fname[0] == 0 {
 		// LFN is invalid: altname needs to be copied to fname.
 		if di == 0 {


### PR DESCRIPTION
I was trying this out and I found that when doing a directory listing I got extra characters in one of my file names;

`hello.txt` would print as `hello.txtxt`

However, I could open and read it as `hello.txt` just fine, and it appeared in my OS as the same.  The block data looked fine as well, even though I don't know how FAT32 works I can see the correct filename.

```
$ sudo head -c 16641536 /dev/disk6 | tail -c 512 | hexyl
...
│000000c0│ 48 45 4c 4c 4f 20 20 20 ┊ 54 58 54 20 18 24 dc b2 │HELLO   ┊TXT •$××│
...
```

I stuck a bunch of debug log lines in until I landed on the fact that the `hello.txt` entry had an invalid LFN while the entry before it `newfile.txt` had a valid LFN.  The `altname` would be left over with `NEWFILE.TXT\x00\x00` and then since `hello.txt` is shorter, it would end as `"HELLO.TXTXT\x00\x00`

My fix was to terminate the `altname` as shown, though I expect there may be a fix inside the invalid LFN block and `for fno.altname[si] != 0 {` instead.

Thanks!